### PR TITLE
Fix "nulib" package DUB warning

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -10,9 +10,9 @@ dependency "numem" version=">=1.3.1"
 dependency "nulib:stdc" version="*"
 
 // OS Integration
-dependency "nulib:os_win32" path="os/os_win32/"
-dependency "nulib:os_posix" path="os/os_posix/"
-// dependency "nulib:os_apple" path="os/os_apple/"
+dependency "nulib:os_win32" version="*"
+dependency "nulib:os_posix" version="*"
+// dependency "nulib:os_apple" version="*"
 
 // Basic configuration
 targetPath "out/"


### PR DESCRIPTION
> Warning Sub package nulib:os_posix, referenced by nulib dub.package_.Package must be referenced using the path to its base package
> Warning Sub package nulib:os_win32, referenced by nulib dub.package_.Package must be referenced using the path to its base package

This removes the warning I believe at low-risk, I've been using "*" for a long time for this, and never saw the base package version being different than the sub-package.